### PR TITLE
Fix saving shown notifs

### DIFF
--- a/bg.js
+++ b/bg.js
@@ -61,7 +61,7 @@ const checkReleased = async () => {
     );
     const newNotifs = await getNewNotifs(gameReleases);
 
-    newNotifs.forEach(async game => {
+    for (const game of newNotifs) {
       chrome.notifications.create({
         type: 'list',
         iconUrl: game.games.results[0].background_image,
@@ -74,7 +74,7 @@ const checkReleased = async () => {
       });
       await saveShownNotif(game.id);
       await sleep(15000);
-    });
+    }
   } catch (e) {
     console.error(e);
     return;

--- a/bg.js
+++ b/bg.js
@@ -32,8 +32,8 @@ const getNewNotifs = async notifs => {
 };
 
 const saveShownNotif = async id => {
-  const list = await getFromSync('shownNotifications');
-  await saveToSync('shownNotifications', [].concat(list, [id]));
+  const list = await getFromSync('shownNotifications') || [];
+  await saveToSync('shownNotifications', list.concat([id]));
 };
 
 const checkReleased = async () => {


### PR DESCRIPTION
Apparently when you use `await` in a `forEach` it will actually just throw away the promise instead of waiting. As a result only one notif was getting marked shown each time notifs were displayed, so I kept getting duplicates 😛. Switching to `for..of` should fix that problem and also make sleeping work as expected. Also a null element was getting stored when list hadn't been initialized yet.